### PR TITLE
Use PUT instead of post for index settings

### DIFF
--- a/lib/tirexs/elastic_search/settings.ex
+++ b/lib/tirexs/elastic_search/settings.ex
@@ -9,7 +9,7 @@ defmodule Tirexs.ElasticSearch.Settings do
     if Resources.exists?(definition[:index], uri) do
       HTTP.delete(definition[:index], uri)
     end
-    HTTP.post(definition[:index], uri, to_resource_json(definition))
+    HTTP.put(definition[:index], uri, to_resource_json(definition))
   end
 
   @doc false


### PR DESCRIPTION
According to the official documentation, we need to se `PUT` instead of `POST` for creating an index with settings. Using POST creates an error (at least in version 5.x of elastic). This solves such error